### PR TITLE
fix(licence): #3 Tranche 1 — clear scaffold-placeholder leak (ProvenCrypto.jl)

### DIFF
--- a/contractiles/dust/Dustfile
+++ b/contractiles/dust/Dustfile
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: PLMP-1.0-or-later
+# SPDX-License-Identifier: PMPL-1.0-or-later
 # Dustfile template - recovery and rollback semantics
 
 version: 1

--- a/contractiles/must/Mustfile
+++ b/contractiles/must/Mustfile
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: PLMP-1.0-or-later
+# SPDX-License-Identifier: PMPL-1.0-or-later
 # Mustfile - declarative state contract (template)
 # See: https://github.com/hyperpolymath/mustfile
 


### PR DESCRIPTION
#3 Tranche 1 (post-pilot #32-shape). Scaffold-placeholder leak per `standards/LICENCE-POLICY.adoc` **A5** — NOT relicensing. PLMP/PMLP + doubled-suffix substituted to this repo's correct id `PMPL-1.0-or-later`. **2 file(s).** Gates: diff-shape asserted (SPDX-only, auto-revert on anomaly), zero residual, no 3c file. 🤖 Generated with [Claude Code](https://claude.com/claude-code)